### PR TITLE
fix: preserve interrupt pipe for copycat controllers over BT

### DIFF
--- a/DS4Windows/DS4Library/DS4Device.cs
+++ b/DS4Windows/DS4Library/DS4Device.cs
@@ -927,11 +927,10 @@ namespace DS4Windows
         {
             if (conType == ConnectionType.BT)
             {
-                //if ((this.featureSet & VidPidFeatureSet.OnlyOutputData0x05) == 0)
-                //    return hDevice.WriteOutputReportViaControl(outputReport);
+                if (nativeOptionsStore != null && nativeOptionsStore.IsCopyCat)
+                    return hDevice.WriteOutputReportViaInterrupt(outputBuffer, READ_STREAM_TIMEOUT);
 
-                // Use Interrupt endpoint for BT DS4 connected devices now
-                return hDevice.WriteOutputReportViaInterrupt(outputBuffer, READ_STREAM_TIMEOUT);
+                return hDevice.WriteOutputReportViaControl(outputBuffer);
             }
             else
             {
@@ -943,11 +942,10 @@ namespace DS4Windows
         {
             if (conType == ConnectionType.BT)
             {
-                //if ((this.featureSet & VidPidFeatureSet.OnlyOutputData0x05) == 0)
-                //    return hDevice.WriteOutputReportViaControl(outputReport);
+                if (nativeOptionsStore != null && nativeOptionsStore.IsCopyCat)
+                    return hDevice.WriteOutputReportViaInterrupt(outputReport, READ_STREAM_TIMEOUT);
 
-                // Use Interrupt endpoint for almost BT DS4 connected devices now
-                return hDevice.WriteOutputReportViaInterrupt(outputReport, READ_STREAM_TIMEOUT);
+                return hDevice.WriteOutputReportViaControl(outputReport);
             }
             else
             {


### PR DESCRIPTION
Copycat (third-party clone) DS4 controllers may not properly support HidD_SetOutputReport on the control pipe. Keep the interrupt pipe for devices flagged as copycats via the IsCopyCat device option, while using the reliable control pipe for genuine DS4 controllers.

(cherry picked from commit 52be18bec68b78d15f81b3967bdcef20116f7873)