### PR TITLE
feat: use HidHide session blacklist for automatic device unhiding on exit

### DIFF
--- a/DS4Windows/DS4Control/ControlService.cs
+++ b/DS4Windows/DS4Control/ControlService.cs
@@ -942,7 +942,33 @@ namespace DS4Windows
             if (Global.hidHideInstalled)
             {
                 dev.CurrentExclusiveStatus = DS4Device.ExclusiveStatus.HidHideAffected;
+                TryAddDeviceToSessionBlacklist(dev);
             }
+        }
+
+        /// <summary>
+        /// Adds the device to HidHide's process-lifetime (session) blacklist.
+        /// The entry is automatically removed by HidHide when DS4Windows exits --
+        /// cleanly or otherwise -- so other apps (Steam, OpenRGB) can reclaim the
+        /// device without requiring a reboot or manual HidHide configuration.
+        /// Falls back silently if the installed HidHide version predates session
+        /// blacklist support.
+        /// </summary>
+        private void TryAddDeviceToSessionBlacklist(DS4Device dev)
+        {
+            if (!Global.hidHideInstalled) return;
+            try
+            {
+                string instanceId = Global.GetInstanceIdFromDevicePath(dev.HidDevice.DevicePath);
+                if (string.IsNullOrEmpty(instanceId)) return;
+
+                using (HidHideAPIDevice hidHideDevice = new HidHideAPIDevice())
+                {
+                    if (!hidHideDevice.IsOpen()) return;
+                    hidHideDevice.AddSessionBlacklist(new System.Collections.Generic.List<string> { instanceId });
+                }
+            }
+            catch { /* HidHide version predates session blacklist -- ignore */ }
         }
 
         private void TestQueueBus(Action temp)

--- a/DS4Windows/DS4Control/HidHideAPIDevice.cs
+++ b/DS4Windows/DS4Control/HidHideAPIDevice.cs
@@ -35,6 +35,8 @@ namespace DS4WinWPF.DS4Control
         private const uint IOCTL_SET_ACTIVE = 0x80016014;
         private const uint IOCTL_GET_WL_INVERT = 0x80016018;
         private const uint IOCTL_SET_WL_INVERT = 0x8001601C;
+        private const uint IOCTL_ADD_SESSION_BLACKLIST = 0x80016020;
+        private const uint IOCTL_CLR_SESSION_BLACKLIST = 0x80016024;
 
         private const string CONTROL_DEVICE_FILENAME = "\\\\.\\HidHide";
 
@@ -157,6 +159,45 @@ namespace DS4WinWPF.DS4Control
             Marshal.FreeHGlobal(inBuffer);
 
             return result;
+        }
+
+        /// <summary>
+        /// Adds device instance paths to a process-lifetime blacklist.
+        /// Entries are automatically removed by HidHide when this process exits,
+        /// regardless of whether the exit is clean or due to a crash.
+        /// Requires HidHide with session blacklist support (v1.5+).
+        /// </summary>
+        public bool AddSessionBlacklist(List<string> instances)
+        {
+            if (instances == null || instances.Count == 0) return true;
+
+            int bytesReturned = 0;
+            IntPtr inBuffer = StringListToMultiSzPointer(instances, out int inBufferLength);
+
+            bool result = NativeMethods.DeviceIoControl(hidHideHandle.DangerousGetHandle(),
+                IOCTL_ADD_SESSION_BLACKLIST,
+                inBuffer,
+                inBufferLength,
+                IntPtr.Zero,
+                0,
+                ref bytesReturned,
+                IntPtr.Zero);
+
+            Marshal.FreeHGlobal(inBuffer);
+            return result;
+        }
+
+        /// <summary>
+        /// Removes all session blacklist entries registered by this process.
+        /// Called automatically by HidHide on process exit; only needed for explicit early release.
+        /// </summary>
+        public bool ClearSessionBlacklist()
+        {
+            int bytesReturned = 0;
+            return NativeMethods.DeviceIoControl(hidHideHandle.DangerousGetHandle(),
+                IOCTL_CLR_SESSION_BLACKLIST,
+                IntPtr.Zero, 0, IntPtr.Zero, 0,
+                ref bytesReturned, IntPtr.Zero);
         }
 
         public List<string> GetWhitelist()


### PR DESCRIPTION
Uses HidHide's process-lifetime (session) blacklist so hidden devices are automatically restored when DS4Windows exits -- cleanly or via crash -- without requiring a reboot or manual HidHide reconfiguration.