### PR TITLE
Fix LastChecked date corruption on non-US locales (parse/format with InvariantCulture)

### DIFF
--- a/DS4Windows/DS4Control/DTOXml/AppSettingsDTO.cs
+++ b/DS4Windows/DS4Control/DTOXml/AppSettingsDTO.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.Design;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -249,10 +250,10 @@ namespace DS4WinWPF.DS4Control.DTOXml
         [XmlElement("LastChecked")]
         public string LastCheckString
         {
-            get => LastChecked.ToString("MM/dd/yyyy HH:mm:ss");
+            get => LastChecked.ToString("MM/dd/yyyy HH:mm:ss", CultureInfo.InvariantCulture);
             set
             {
-                if (DateTime.TryParse(value, out DateTime temp))
+                if (DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime temp))
                 {
                     LastChecked = temp;
                 }

--- a/DS4WindowsTests/AppSettingsTests.cs
+++ b/DS4WindowsTests/AppSettingsTests.cs
@@ -18,6 +18,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 using System.Configuration;
 using System;
+using System.Globalization;
 using System.Text;
 using System.Xml;
 using System.Xml.Serialization;
@@ -132,7 +133,7 @@ namespace DS4WindowsTests
             dto.MapTo(tempStore);
 
             // Check settings
-            DateTime.TryParse(dto.LastCheckString, out DateTime tempLastChecked);
+            DateTime.TryParse(dto.LastCheckString, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime tempLastChecked);
             Assert.AreEqual(tempLastChecked, tempStore.lastChecked);
         }
 


### PR DESCRIPTION
`AppSettingsDTO.LastCheckString` writes the `LastChecked` date as `MM/dd/yyyy` (month-first) but reads it back with a culture-dependent `DateTime.TryParse`. On a non-US locale the parse reads `MM/dd` as `dd/MM`, so a saved `LastChecked` round-trips to the **wrong date — month and day swapped**. A settings file written on one machine gets a corrupted `LastChecked` when read on a machine with a different locale.

**Fix:** use `CultureInfo.InvariantCulture` for both the format and the parse, so the value round-trips consistently regardless of the machine's culture. I also made the existing `CheckSettingsRead` assertion's own parse culture-invariant — it currently fails on non-US locales because it re-parses the value with the current culture.

**Before/after** (on an `en-GB` machine):
- **Before:** `CheckSettingsRead` fails — `Assert.AreEqual failed. Expected:<05/12/2023 00:24:15>. Actual:<12/05/2023 00:24:15>.` (month/day swapped on round-trip).
- **After:** `CheckSettingsRead` passes; the full test suite (with the repo's documented CI exclusions) is green — 12/12.

A normal US-locale CI run doesn't surface this, which is why it's gone unnoticed.


---
<sub>Local review history: https://gist.github.com/e1d6299912b5f55dba818b128290b2bb</sub>


## Proof manifest

Structured before/after manifest for the red-green evidence already in this description (CheckSettingsRead fails on en-GB before, passes after; full suite 12/12 after).

Manifest + raw run outputs: https://gist.github.com/anagnorisis2peripeteia/362f9cb73c6c229d9eb1b04a4e7d9bb4
