### PR TITLE
Add value-band parsing tests for MacroParser

### DIFF
--- a/DS4WindowsTests/MacroParserTests.cs
+++ b/DS4WindowsTests/MacroParserTests.cs
@@ -79,5 +79,119 @@ namespace DS4WindowsTests
 
             return;
         }
+
+        // A macro covering every ParseStep value band, with predictable output names.
+        private static readonly int[] BandMacro = new int[]
+        {
+            800,        // 0: Wait (value - 300 = 500 ms)
+            261,        // 1: A Button down (261 > 255 => Button, first press)
+            261,        // 2: A Button up (same value again => release)
+            1000000,    // 3: Stop Rumble (exactly 1000000 => reset)
+            1255255,    // 4: Rumble down (heavy 255, light 255)
+            1000000000, // 5: Reset Lightbar (exactly 1000000000 => reset)
+            1100200050, // 6: Lightbar Color 100,200,50
+            286,        // 7: Touchpad Click down (286 > 255 => Button)
+        };
+
+        [TestMethod]
+        public void CheckBandParsingTypesAndNames()
+        {
+            MacroParser bandParser = new MacroParser(BandMacro);
+            bandParser.LoadMacro();
+            List<MacroStep> steps = bandParser.MacroSteps;
+
+            Assert.AreEqual(BandMacro.Length, steps.Count);
+
+            // 0: Wait band (value >= 300)
+            Assert.AreEqual(MacroStep.StepType.Wait, steps[0].ActType);
+            Assert.AreEqual(MacroStep.StepOutput.None, steps[0].OutputType);
+            Assert.AreEqual("Wait 500 ms", steps[0].Name);
+
+            // 1/2: Button press then release for the same value (keydown tracking)
+            Assert.AreEqual(MacroStep.StepOutput.Button, steps[1].OutputType);
+            Assert.AreEqual(MacroStep.StepType.ActDown, steps[1].ActType);
+            Assert.AreEqual("A Button", steps[1].Name);
+            Assert.AreEqual(MacroStep.StepOutput.Button, steps[2].OutputType);
+            Assert.AreEqual(MacroStep.StepType.ActUp, steps[2].ActType);
+            Assert.AreEqual("A Button", steps[2].Name);
+
+            // 3: Rumble reset (value == 1000000)
+            Assert.AreEqual(MacroStep.StepOutput.Rumble, steps[3].OutputType);
+            Assert.AreEqual(MacroStep.StepType.ActUp, steps[3].ActType);
+            Assert.AreEqual("Stop Rumble", steps[3].Name);
+
+            // 4: Rumble down (heavy/light decoded from the digits)
+            Assert.AreEqual(MacroStep.StepOutput.Rumble, steps[4].OutputType);
+            Assert.AreEqual(MacroStep.StepType.ActDown, steps[4].ActType);
+            Assert.IsTrue(steps[4].Name.StartsWith("Rumble 255, 255"),
+                $"Unexpected rumble name: {steps[4].Name}");
+            Assert.IsTrue(steps[4].Name.EndsWith("%)"),
+                $"Unexpected rumble name: {steps[4].Name}");
+
+            // 5: Lightbar reset (value == 1000000000)
+            Assert.AreEqual(MacroStep.StepOutput.Lightbar, steps[5].OutputType);
+            Assert.AreEqual(MacroStep.StepType.ActUp, steps[5].ActType);
+            Assert.AreEqual("Reset Lightbar", steps[5].Name);
+
+            // 6: Lightbar color (value > 1000000000, RGB decoded from the digits)
+            Assert.AreEqual(MacroStep.StepOutput.Lightbar, steps[6].OutputType);
+            Assert.AreEqual(MacroStep.StepType.ActDown, steps[6].ActType);
+            Assert.AreEqual("Lightbar Color: 100,200,50", steps[6].Name);
+
+            // 7: Button from the named-input table
+            Assert.AreEqual(MacroStep.StepOutput.Button, steps[7].OutputType);
+            Assert.AreEqual(MacroStep.StepType.ActDown, steps[7].ActType);
+            Assert.AreEqual("Touchpad Click", steps[7].Name);
+        }
+
+        [TestMethod]
+        public void CheckKeyButtonBoundary()
+        {
+            // 255 is the last Key value; 256 is the first Button value.
+            MacroParser boundaryParser = new MacroParser(new int[] { 255, 256 });
+            boundaryParser.LoadMacro();
+            List<MacroStep> steps = boundaryParser.MacroSteps;
+
+            Assert.AreEqual(MacroStep.StepOutput.Key, steps[0].OutputType);
+            Assert.AreEqual(MacroStep.StepOutput.Button, steps[1].OutputType);
+            Assert.AreEqual("Left Mouse Button", steps[1].Name);
+        }
+
+        [TestMethod]
+        public void CheckWaitBoundary()
+        {
+            // 300 is the exact wait threshold => 0 ms wait.
+            MacroParser waitParser = new MacroParser(new int[] { 300 });
+            waitParser.LoadMacro();
+            List<MacroStep> steps = waitParser.MacroSteps;
+
+            Assert.AreEqual(MacroStep.StepType.Wait, steps[0].ActType);
+            Assert.AreEqual("Wait 0 ms", steps[0].Name);
+        }
+
+        [TestMethod]
+        public void CheckLoadMacroIsIdempotent()
+        {
+            MacroParser repeatParser = new MacroParser(new int[] { 800 });
+            repeatParser.LoadMacro();
+            int firstCount = repeatParser.MacroSteps.Count;
+            repeatParser.LoadMacro();
+
+            Assert.AreEqual(firstCount, repeatParser.MacroSteps.Count);
+        }
+
+        [TestMethod]
+        public void CheckGetMacroStringsMatchesSteps()
+        {
+            MacroParser stringParser = new MacroParser(BandMacro);
+            List<string> names = stringParser.GetMacroStrings();
+            List<MacroStep> steps = stringParser.MacroSteps;
+
+            Assert.AreEqual(steps.Count, names.Count);
+            for (int i = 0; i < steps.Count; i++)
+            {
+                Assert.AreEqual(steps[i].Name, names[i]);
+            }
+        }
     }
 }


### PR DESCRIPTION
A follow-up to #37. `MacroParser.ParseStep` maps an int to a macro step across four value bands — key/button, wait, rumble, lightbar — but the existing `MacroParserTests` only assert step *types* on one fixed macro. The generated step *names* and the band boundaries aren't checked, so the string formatting and threshold arithmetic go unasserted.

This adds five tests:

- `CheckBandParsingTypesAndNames` — one macro that hits every band, asserting `ActType`/`OutputType` and the exact output name for each step (e.g. `Wait 500 ms`, `Reset Lightbar`, `Lightbar Color: 100,200,50`, and an `A Button` press→release pair to exercise the keydown tracking).
- `CheckKeyButtonBoundary` — 255 → `Key`, 256 → `Button` (the `value <= 255` split).
- `CheckWaitBoundary` — 300 → `Wait 0 ms` (the exact wait threshold).
- `CheckLoadMacroIsIdempotent` — a second `LoadMacro()` is a no-op.
- `CheckGetMacroStringsMatchesSteps` — `GetMacroStrings()` lines up with `MacroSteps`.

Test-only; no behaviour change.


---
<sub>Local review history: https://gist.github.com/38216573a8983d1689a92a8e209e92e6</sub>


## Proof manifest

Fault-injection proof (test-only PR): off-by-one'd the wait-band arithmetic (`value - 300` -> `value - 299`) identically on base and this branch. **Base + fault: suite passes (fault missed). This branch + fault: `CheckBandParsingTypesAndNames` fails (fault caught). Clean branch: suite passes.**

Manifest + raw run outputs: https://gist.github.com/anagnorisis2peripeteia/0a3f4b5f50141ffc8a670a77f412c55b
