### PR TITLE
Remove assigned-but-never-read fields and unused catch variable

### DIFF
--- a/DS4Windows/DS4Control/Mouse.cs
+++ b/DS4Windows/DS4Control/Mouse.cs
@@ -151,8 +151,6 @@ namespace DS4Windows
         public void ResetToggleGyroModes()
         {
             currentToggleGyroControls = false;
-            currentToggleGyroMouse = false;
-            currentToggleGyroStick = false;
 
             previousGyroControlsTriggerActivated = false;
             previousGyroMouseTriggerActivated = false;
@@ -223,8 +221,6 @@ namespace DS4Windows
         }
 
         bool currentToggleGyroControls = false;
-        bool currentToggleGyroMouse = false;
-        bool currentToggleGyroStick = false;
 
         bool previousUnchangedTouchJoyFrame = false;
         int previousTouchDX = 0;

--- a/DS4Windows/DS4Control/ScpUtil.cs
+++ b/DS4Windows/DS4Control/ScpUtil.cs
@@ -8505,7 +8505,7 @@ namespace DS4Windows
 
                     PostProcessLoad();
                 }
-                catch (InvalidOperationException e)
+                catch (InvalidOperationException)
                 {
                     AppLogger.LogToGui("Failed to load Profiles.xml.", false);
                     loaded = false;


### PR DESCRIPTION
Part of #38 (dead-code audit).

## What

Remove three analyzer-flagged dead values that are never read:

- `Mouse.currentToggleGyroMouse` / `currentToggleGyroStick` (CS0414) — written in
  `ResetToggleGyroModes()` but never read anywhere. Removed the fields and their two writes.
  (`currentToggleGyroControls`, which *is* read, is kept.)
- The unused exception variable in `ScpUtil`'s Profiles.xml load catch (CS0168):
  `catch (InvalidOperationException e)` -> `catch (InvalidOperationException)`.

No behavior change.

## How verified

Unlike removing an unreferenced declaration or an unused `using` (where "it compiles" already
implies "safe"), removing an *assigned-but-never-read* value could silently drop a side effect —
so each was checked by hand first: both gyro fields are only ever assigned `= false` (no side
effect), and dropping an unused catch identifier doesn't change which exception is caught. Then
compiled:

```
x64 Release publish : PUBLISH_X64_EXIT=0
x86 Release publish : PUBLISH_X86_EXIT=0
DS4WindowsTests     : Passed 11, Failed 1, Total 12
```

The single test failure (`CheckSettingsRead`) is a pre-existing en-GB date-locale snapshot
mismatch, identical on untouched `upstream/main`.

## Scope

Deliberately limited to values whose removal is provably side-effect-free. Two further
assigned-never-read candidates — `ControlService.useRumble` (duplicate near-identical code
blocks) and `DS4Device.outputPendCount` (private base field vs subclass shadowing) — are held
back for a traced follow-up rather than a mechanical removal.

Authored with Claude (Opus 4.8).

---
Review history: https://gist.github.com/00b6e96ba78cc14bc88376b161925ded
