### PR TITLE
Add ProfileMigration version-migration coverage tests

### DIFF
--- a/DS4WindowsTests/ProfileMigrationTests.cs
+++ b/DS4WindowsTests/ProfileMigrationTests.cs
@@ -20,6 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 using System.Text;
 using System.Xml;
 using System.Xml.Serialization;
+using System.Xml.Linq;
 using DS4Windows;
 using DS4WinWPF.DS4Control.DTOXml;
 
@@ -457,6 +458,138 @@ namespace DS4WindowsTests
             }
 
             return testStr;
+        }
+
+        private static XDocument GetMigratedDocument(ProfileMigration migration)
+        {
+            return XDocument.Parse(migration.CurrentMigrationText);
+        }
+
+        [TestMethod]
+        public void RequiresMigration_ReturnsTrueForOldAndAbsentConfigVersion()
+        {
+            Assert.IsTrue(new ProfileMigration(@"<DS4Windows config_version=""1""></DS4Windows>").RequiresMigration());
+            Assert.IsTrue(new ProfileMigration(@"<DS4Windows><LSAntiDeadZone>20</LSAntiDeadZone></DS4Windows>").RequiresMigration());
+        }
+
+        [TestMethod]
+        public void RequiresMigration_ReturnsFalseForCurrentVersion_AndUsedMigrationStaysFalse()
+        {
+            ProfileMigration migration = new ProfileMigration($@"<DS4Windows config_version=""{Global.CONFIG_VERSION}""></DS4Windows>");
+            Assert.IsFalse(migration.RequiresMigration());
+            migration.Migrate();
+            Assert.IsFalse(migration.UsedMigration);
+            migration.Close();
+        }
+
+        [TestMethod]
+        public void Migrate_TransformsVersion0002_DeadzoneDefaults()
+        {
+            string version1Profile =
+                @"<DS4Windows config_version=""1"">
+                    <LSDeadZone>0</LSDeadZone>
+                    <RSDeadZone>5</RSDeadZone>
+                  </DS4Windows>";
+
+            ProfileMigration migration = new ProfileMigration(version1Profile);
+            migration.Migrate();
+
+            Assert.IsTrue(migration.UsedMigration);
+
+            XDocument profileDocument = GetMigratedDocument(migration);
+            Assert.AreEqual(Global.CONFIG_VERSION.ToString(), profileDocument.Root?.Attribute("config_version")?.Value);
+            // A non-positive LSDeadZone is normalized to the default; a positive RSDeadZone is left as-is.
+            Assert.AreEqual(StickDeadZoneInfo.DEFAULT_DEADZONE.ToString(), profileDocument.Root?.Element("LSDeadZone")?.Value);
+            Assert.AreEqual("5", profileDocument.Root?.Element("RSDeadZone")?.Value);
+
+            migration.Close();
+        }
+
+        [TestMethod]
+        public void Migrate_TransformsVersion0004_GyroSmoothingGroups()
+        {
+            string version2Profile =
+                @"<DS4Windows config_version=""2"">
+                    <GyroSmoothing>True</GyroSmoothing>
+                    <GyroSmoothingWeight>15</GyroSmoothingWeight>
+                    <GyroMouseStickSmoothing>False</GyroMouseStickSmoothing>
+                    <GyroMouseStickSmoothingWeight>20</GyroMouseStickSmoothingWeight>
+                  </DS4Windows>";
+
+            ProfileMigration migration = new ProfileMigration(version2Profile);
+            migration.Migrate();
+
+            Assert.IsTrue(migration.UsedMigration);
+
+            XDocument profileDocument = GetMigratedDocument(migration);
+            Assert.AreEqual(Global.CONFIG_VERSION.ToString(), profileDocument.Root?.Attribute("config_version")?.Value);
+
+            XElement gyroMouseSmoothing = profileDocument.Root?.Element("GyroMouseSmoothingSettings");
+            Assert.IsNotNull(gyroMouseSmoothing);
+            Assert.AreEqual("True", gyroMouseSmoothing.Element("UseSmoothing")?.Value);
+            Assert.AreEqual("weighted-average", gyroMouseSmoothing.Element("SmoothingMethod")?.Value);
+            Assert.AreEqual("15", gyroMouseSmoothing.Element("SmoothingWeight")?.Value);
+
+            XElement gyroMouseStickSmoothing = profileDocument.Root?.Element("GyroMouseStickSmoothingSettings");
+            Assert.IsNotNull(gyroMouseStickSmoothing);
+            Assert.AreEqual("False", gyroMouseStickSmoothing.Element("UseSmoothing")?.Value);
+            Assert.IsNull(gyroMouseStickSmoothing.Element("SmoothingMethod"));
+            Assert.AreEqual("20", gyroMouseStickSmoothing.Element("SmoothingWeight")?.Value);
+
+            Assert.IsNull(profileDocument.Root?.Element("GyroSmoothing"));
+            Assert.IsNull(profileDocument.Root?.Element("GyroSmoothingWeight"));
+            Assert.IsNull(profileDocument.Root?.Element("GyroMouseStickSmoothing"));
+            Assert.IsNull(profileDocument.Root?.Element("GyroMouseStickSmoothingWeight"));
+
+            migration.Close();
+        }
+
+        [TestMethod]
+        public void Migrate_TransformsVersion0005_UseTPforControls()
+        {
+            string version4Profile =
+                @"<DS4Windows config_version=""4"">
+                    <UseTPforControls>True</UseTPforControls>
+                  </DS4Windows>";
+
+            ProfileMigration migration = new ProfileMigration(version4Profile);
+            migration.Migrate();
+
+            Assert.IsTrue(migration.UsedMigration);
+
+            XDocument profileDocument = GetMigratedDocument(migration);
+            Assert.AreEqual(Global.CONFIG_VERSION.ToString(), profileDocument.Root?.Attribute("config_version")?.Value);
+            Assert.AreEqual(TouchpadOutMode.Controls.ToString(),
+                profileDocument.Root?.Element("TouchpadOutputMode")?.Value);
+            Assert.IsNull(profileDocument.Root?.Element("UseTPforControls"));
+
+            migration.Close();
+        }
+
+        [TestMethod]
+        public void DetermineProfileVersion_DetectsVersion2ForConfigVersionAbsentWithLSAntiDeadZone()
+        {
+            string noVersionProfile =
+                @"<DS4Windows>
+                    <LSAntiDeadZone>20</LSAntiDeadZone>
+                    <LSDeadZone>0</LSDeadZone>
+                  </DS4Windows>";
+
+            ProfileMigration migration = new ProfileMigration(noVersionProfile);
+
+            Assert.IsTrue(migration.RequiresMigration());
+
+            migration.Migrate();
+
+            XDocument profileDocument = GetMigratedDocument(migration);
+            Assert.AreEqual(Global.CONFIG_VERSION.ToString(), profileDocument.Root?.Attribute("config_version")?.Value);
+
+            // If this were version 1, Version0002 would map LSDeadZone 0 -> default.
+            // Version 2 detection via LSAntiDeadZone keeps the original 0 value.
+            Assert.AreEqual("0", profileDocument.Root?.Element("LSDeadZone")?.Value);
+            Assert.AreEqual("20", profileDocument.Root?.Element("LSAntiDeadZone")?.Value);
+
+            migration.Close();
         }
     }
 }


### PR DESCRIPTION
A follow-up to #37. `ProfileMigration` upgrades old controller-profile XML to the current format (`config_version` 5) through a chain of steps, but only two tests cover it — and one of those (`CheckJaysProfileRead`) is excluded from CI for snapshot fragility — so the per-step migration logic is largely unasserted.

This adds six tests that assert migration **behaviour** with targeted attribute/element checks (deliberately not full-document string diffs, which is what got the existing test excluded):

- `RequiresMigration` for old (`config_version=1`), absent, and current (`=5`) profiles.
- After `Migrate()`, `config_version` reaches the current version and `UsedMigration` is set — and stays `false` for an already-current profile.
- `Version0002`: a non-positive `LSDeadZone` is normalized to the default deadzone; a positive value passes through.
- `Version0004`: legacy `GyroSmoothing*` nodes become the `GyroMouseSmoothingSettings` / `GyroMouseStickSmoothingSettings` groups (with the conditional `SmoothingMethod`).
- `Version0005`: `UseTPforControls` remaps to `TouchpadOutputMode`.
- `DetermineProfileVersion`: a version-absent profile containing `LSAntiDeadZone` is detected as v2 (its `LSDeadZone` is preserved, not v1-normalized).

Test-only; no behaviour change.


---
<sub>Local review history: https://gist.github.com/fc75801ef643a30731c2b87394c3a935</sub>


## Proof manifest

### Before / After (same command, same machine)

```
dotnet test DS4WindowsTests\DS4WindowsTests.csproj -c Release -p:Platform=x64 --filter "Name!=CheckSettingsSave&Name!=CheckWriteProfile&Name!=CheckJaysProfileRead&Name!=CheckSettingsRead"
```

| Run | Result |
|---|---|
| **Base + injected fault** (`Version0005` writes `Mouse` instead of `Controls`) | ✅ suite passes — fault **missed** (the coverage gap) |
| **This branch + the same fault** | ❌ `Migrate_TransformsVersion0005_UseTPforControls` fails — fault **caught** |
| **This branch, clean** | ✅ suite passes |


Fault-injection proof (test-only PR): made `Version0005` write `TouchpadOutMode.Mouse` instead of `Controls`, identically on base and this branch. **Base + fault: suite passes (fault missed). This branch + fault: `Migrate_TransformsVersion0005_UseTPforControls` fails (fault caught). Clean branch: suite passes.** Mutation delta on `ProfileMigration.cs`: 28.0% -> 59.2%, posted above.

Manifest + raw run outputs: https://gist.github.com/anagnorisis2peripeteia/f78f8b91812cb8d3b6009be38c42b2df
