### PR TITLE
Fix legacy Green/Blue lightbar channels parsing the Red element's value

### DIFF
--- a/DS4Windows/DS4Control/DTOXml/ProfileDTO.cs
+++ b/DS4Windows/DS4Control/DTOXml/ProfileDTO.cs
@@ -2769,12 +2769,12 @@ namespace DS4WinWPF.DS4Control.DTOXml
 
                 if (!string.IsNullOrEmpty(GreenColorString))
                 {
-                    byte.TryParse(RedColorString, out _ledColor.green);
+                    byte.TryParse(GreenColorString, out _ledColor.green);
                 }
 
                 if (!string.IsNullOrEmpty(BlueColorString))
                 {
-                    byte.TryParse(RedColorString, out _ledColor.blue);
+                    byte.TryParse(BlueColorString, out _ledColor.blue);
                 }
             }
 

--- a/DS4WindowsTests/ProfileTests.cs
+++ b/DS4WindowsTests/ProfileTests.cs
@@ -524,5 +524,32 @@ namespace DS4WindowsTests
             Assert.AreEqual(OutContType.ViiperX360,
                 roundTripStore.outputDevType[0]);
         }
+
+        [TestMethod]
+        public void CheckLegacyPerChannelColorRead()
+        {
+            // Old profiles store the lightbar colour as separate <Red>/<Green>/<Blue>
+            // elements rather than a combined <Color>. Each channel must be parsed
+            // from its own element.
+            string legacyColorProfileXml = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<DS4Windows config_version=""5"">
+  <Red>10</Red>
+  <Green>20</Green>
+  <Blue>30</Blue>
+</DS4Windows>";
+
+            XmlSerializer serializer = new XmlSerializer(typeof(ProfileDTO),
+                ProfileDTO.GetAttributeOverrides());
+            using StringReader sr = new StringReader(legacyColorProfileXml);
+            ProfileDTO dto = serializer.Deserialize(sr) as ProfileDTO;
+            dto.DeviceIndex = 0;
+            BackingStore tempStore = new BackingStore();
+            dto.MapTo(tempStore);
+
+            DS4Color led = tempStore.lightbarSettingInfo[0].ds4winSettings.m_Led;
+            Assert.AreEqual((byte)10, led.red);
+            Assert.AreEqual((byte)20, led.green);
+            Assert.AreEqual((byte)30, led.blue);
+        }
     }
 }


### PR DESCRIPTION
In `ProfileDTO.PostProcessXml`, the legacy per-channel lightbar colour path parses the wrong source strings: the green and blue channels both read `RedColorString` instead of `GreenColorString` / `BlueColorString`. A profile that stores its colour as the old separate `<Red>/<Green>/<Blue>` elements (rather than the combined `<Color>`) loads with **all three channels set to the red value**, so the lightbar shows the wrong colour.

**The fix:** parse each channel from its own element (two-line change), plus a regression test that deserializes a legacy per-channel profile (`Red=10, Green=20, Blue=30`) and asserts the mapped `DS4Color` channels individually.

**Before/after:**
- **Before:** the new test fails — `Assert.AreEqual failed. Expected:<20>. Actual:<10>` (green channel received red's value).
- **After:** it passes; the full suite (with the repo's documented CI exclusions) shows no new failures.

Bug 2 of #46 — found while mutation-testing the profile-serialization code (#37): the surviving mutants pointed at this block being unasserted, and reading it turned up the copy-paste slip.


---
<sub>Local review history: https://gist.github.com/anagnorisis2peripeteia/b97ed542427a5e3fe0184c8074873a24</sub>


## Proof manifest

### Before / After (same command, same machine)

```
dotnet test DS4WindowsTests\DS4WindowsTests.csproj -c Release -p:Platform=x64 --filter "Name=CheckLegacyPerChannelColorRead"
```

| Run | Result |
|---|---|
| **Base** (`ba4bdcb`) | ❌ `Assert.AreEqual failed. Expected:<20>. Actual:<10>.` — green channel received the Red element's value |
| **This branch** (`aef33d4`) | ✅ passes; full suite shows no new failures; x64/x86 publishes clean |


Structured before/after manifest for the red-green evidence already in this description (regression test Expected:<20> Actual:<10> on base; passes on this branch; no new failures in the full suite).

Manifest + raw run outputs: https://gist.github.com/anagnorisis2peripeteia/5f618fc106fac64e4baa18fc28636a8e
