### PR TITLE
Document local build/test steps in contributing.md

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -6,3 +6,21 @@ the performance of other parts of the application. Some consideration will
 be made during code review to try to tweak the changes in order to improve
 application performance. However, there is a chance that a pull request will be
 rejected if no reasonable solution can be found to incorporate code changes.
+
+## Before opening a pull request
+
+DS4Windows targets .NET 8 on Windows. Please build both platforms and run the tests
+locally first. These are the same steps CI runs (`.github/workflows/ci-build.yml`):
+
+    dotnet restore
+    dotnet test .\DS4WindowsTests\DS4WindowsTests.csproj -c Release -p:Platform=x64
+    dotnet publish .\DS4Windows\DS4WinWPF.csproj -c Release /p:platform=x64 -o .\bin\x64\Release\output
+    dotnet publish .\DS4Windows\DS4WinWPF.csproj -c Release /p:platform=x86 -o .\bin\x86\Release\output
+
+Both x64 and x86 must build and the tests should pass. After you open the PR, check
+that the CI build is green.
+
+> Three serialization "snapshot" tests (`CheckSettingsSave`, `CheckWriteProfile`,
+> `CheckJaysProfileRead`) currently fail on a clean checkout: their expected-XML fixtures
+> predate fields the serializer now emits. CI skips them with `--filter`, so you can
+> ignore those three until the fixtures are regenerated.


### PR DESCRIPTION
Adds a "Before opening a pull request" section to `contributing.md` with the exact
build + test commands (mirroring `.github/workflows/ci-build.yml`), so new contributors
know what to run locally before submitting.

It also notes that three serialization snapshot tests (`CheckSettingsSave`,
`CheckWriteProfile`, `CheckJaysProfileRead`) fail on a clean checkout (stale expected-XML
fixtures) and are skipped by CI's `--filter`, so contributors aren't tripped up by those
pre-existing failures.

Docs-only; no code change.

Authored with Claude (Opus 4.8).
