### PR TITLE
Fix shift-modifier Extras lost on save and misapplied on load

### DIFF
--- a/DS4Windows/DS4Control/DTOXml/ProfileDTO.cs
+++ b/DS4Windows/DS4Control/DTOXml/ProfileDTO.cs
@@ -2068,6 +2068,11 @@ namespace DS4WinWPF.DS4Control.DTOXml
                         }
                     }
                 }
+
+                if (hasExtrasValue)
+                {
+                    shiftExtrasSerializer.CustomMapExtras.Add(dcs.control, dcs.shiftExtras);
+                }
             }
 
             if (buttonSerializer.CustomMapButtons.Count > 0)
@@ -2735,7 +2740,7 @@ namespace DS4WinWPF.DS4Control.DTOXml
                     foreach (KeyValuePair<DS4Controls, string> pair in ShiftControl.Extras.CustomMapExtras)
                     {
                         destination.UpdateDS4CExtra(deviceIndex,
-                            pair.Key.ToString(), false, pair.Value);
+                            pair.Key.ToString(), true, pair.Value);
                     }
                 }
 

--- a/DS4WindowsTests/ProfileTests.cs
+++ b/DS4WindowsTests/ProfileTests.cs
@@ -524,5 +524,57 @@ namespace DS4WindowsTests
             Assert.AreEqual(OutContType.ViiperX360,
                 roundTripStore.outputDevType[0]);
         }
+
+        [TestMethod]
+        public void CheckShiftExtrasWrittenOnSave()
+        {
+            // Shift-modifier extras stored in the BackingStore must survive MapFrom
+            // into the DTO's ShiftControl.Extras so they get serialized.
+            string shiftExtras = "1,255,0,0,255,0,0,1,0";
+            BackingStore tempStore = new BackingStore();
+            tempStore.UpdateDS4CExtra(0, "Cross", true, shiftExtras);
+
+            ProfileDTO dto = new ProfileDTO();
+            dto.DeviceIndex = 0;
+            dto.MapFrom(tempStore);
+
+            Assert.IsNotNull(dto.ShiftControl.Extras);
+            Assert.IsTrue(dto.ShiftControl.Extras.CustomMapExtras.ContainsKey(DS4Controls.Cross));
+            Assert.AreEqual(shiftExtras, dto.ShiftControl.Extras.CustomMapExtras[DS4Controls.Cross]);
+        }
+
+        [TestMethod]
+        public void CheckShiftExtrasReadIntoShiftSlot()
+        {
+            // ShiftControl/Extras in the profile XML must load into the control's
+            // shift extras slot without clobbering its normal extras.
+            string normalExtras = "1,255,0,0,255,0,0,1,0";
+            string shiftExtras = "1,0,255,0,255,0,0,1,0";
+            string profileXml = $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<DS4Windows config_version=""5"">
+  <Control>
+    <Extras>
+      <Cross>{normalExtras}</Cross>
+    </Extras>
+  </Control>
+  <ShiftControl>
+    <Extras>
+      <Cross>{shiftExtras}</Cross>
+    </Extras>
+  </ShiftControl>
+</DS4Windows>";
+
+            XmlSerializer serializer = new XmlSerializer(typeof(ProfileDTO),
+                ProfileDTO.GetAttributeOverrides());
+            using StringReader sr = new StringReader(profileXml);
+            ProfileDTO dto = serializer.Deserialize(sr) as ProfileDTO;
+            dto.DeviceIndex = 0;
+            BackingStore tempStore = new BackingStore();
+            dto.MapTo(tempStore);
+
+            DS4ControlSettings dcs = tempStore.GetDS4CSetting(0, "Cross");
+            Assert.AreEqual(normalExtras, dcs.extras);
+            Assert.AreEqual(shiftExtras, dcs.shiftExtras);
+        }
     }
 }


### PR DESCRIPTION
Bugs 3 and 4 of #46 — the two halves of the shift-modifier Extras round-trip, found while mutation-testing the profile-serialization code (#37).

**Save side:** `ProfileDTO.MapFrom` recomputes `hasExtrasValue` from `dcs.shiftExtras` but was missing the trailing add into `shiftExtrasSerializer` that its non-shift sibling has, so `ShiftControl/Extras` was never written to the profile XML — shift-mode extras (rumble/lightbar/mouse-sensitivity under a shift trigger) silently vanished on every save. (The old pre-DTO writer in `SaveProfileOld` appends the node right after the identical recompute, which is how the block lost its tail in the DTO port.)

**Load side:** `MapTo`'s `ShiftControl.Extras` block still passed `shift=false` to `UpdateDS4CExtra` — unedited from the copied `Control.Extras` block, while every other `ShiftControl` sub-block passes `true` — so shift extras from older profiles loaded into the *normal* extras slot: firing without the shift trigger held and clobbering the control's normal extras.

**The change:** add the missing append, pass `true` for the shift slot, and cover both directions with regression tests (`CheckShiftExtrasWrittenOnSave`, `CheckShiftExtrasReadIntoShiftSlot`).

## Before / After

Same command on base `ba4bdcb` and this branch (`2cc9bb0`), same machine:

```
dotnet test DS4WindowsTests\DS4WindowsTests.csproj -c Release -p:Platform=x64 --filter "Name~CheckShiftExtras"
```

| | Result |
|---|---|
| **Before** (base + the two tests) | ❌ Failed: 2/2 — `ShiftControl.Extras` stays null on save; on load the shift value lands in `extras` and `shiftExtras` stays null |
| **After** (this branch) | ✅ Passed: 2/2 — full suite 13/14 (the one failure is the pre-existing en-GB `CheckSettingsRead` date bug, fixed separately in #42); x64/x86 publishes clean |

Full proof manifest + raw test outputs: https://gist.github.com/anagnorisis2peripeteia/3352cb2abb916edab1e6ae5ff7f882f1

---
<sub>Local review history: https://gist.github.com/anagnorisis2peripeteia/651881943f6c1b32d781cad8aa2cc548</sub>
